### PR TITLE
AIレビューをCodeRabbitからPR-Agentに変更 #2

### DIFF
--- a/.github/workflow/ai-review.yaml
+++ b/.github/workflow/ai-review.yaml
@@ -1,68 +1,51 @@
-# https://zenn.dev/minedia/articles/7928ef7545b393より
+# https://recruit.gmo.jp/engineer/jisedai/blog/chatgpt-pr-agent-github-actions/
 
-name: ai-pr-reviewer
-
-permissions:
-  contents: read
-  pull-requests: write
-
+name: PR-Agent
 on:
   pull_request:
-    types: [opened]
-    branches-ignore:
-      - main
-  pull_request_review_comment:
-    types: [created]
-  issue_comment:
-    types: [created]
+    types: [opened, reopened, synchronize]
 
-concurrency:
-  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}-${{ github.event_name == 'pull_request_review_comment' && 'pr_comment' || 'pr' }}
-  cancel-in-progress: ${{ github.event_name != 'pull_request_review_comment' }}
+  issue_comment:
+    types: [created, edited]
+  
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
-  review:
+  pr_agent_job:
+    if: contains(github.event.pull_request.labels.*.name, 'AIレビュー対象') || contains(github.event.issue.labels.*.name, 'AIレビュー対象')
     runs-on: ubuntu-latest
-    if: (github.event_name == 'issue_comment' && contains(github.event.comment.body, '[run review]') && github.event.issue.pull_request) ||　(github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '[run review]')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, 'release') && !contains(github.event.pull_request.title, 'Release'))
-    timeout-minutes: 15
+    name: Run pr agent on every pull request
     steps:
-      - uses: coderabbitai/openai-pr-reviewer@latest
+      - name: PR Agent action step
+        id: pragent
+        uses: Codium-ai/pr-agent@main
         env:
+          OPENAI_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        with:
-          debug: false
-          review_simple_changes: false
-          review_comment_lgtm: false
-          openai_light_model: gpt-3.5-turbo
-          openai_heavy_model: gpt-4o
-          openai_timeout_ms: 900000
-          language: ja-JP
-          path_filters: |
-            !db/**
-            !**/*.lock
-          system_message: |
-            あなたは @coderabbitai（別名 github-actions[bot]）で、OpenAIによって訓練された言語モデルです。
-            あなたの目的は、非常に経験豊富なソフトウェアエンジニアとして機能し、コードの一部を徹底的にレビューし、
-            以下のようなキーエリアを改善するためのコードスニペットを提案することです：
-              - ロジック
-              - セキュリティ
-              - パフォーマンス
-              - データ競合
-              - 一貫性
-              - エラー処理
-              - 保守性
-              - モジュール性
-              - 複雑性
-              - 最適化
-              - ベストプラクティス: DRY, SOLID, KISS
+          CONFIG.model: gpt-4o-mini
+          CONFIG.model_turbo: gpt-4o-mini
 
-            些細なコードスタイルの問題や、コメント・ドキュメントの欠落についてはコメントしないでください。
-            重要な問題を特定し、解決して全体的なコード品質を向上させることを目指し、細かい問題は意図的に無視してください。
-          summarize: |
-            次の内容でmarkdownフォーマットを使用して、最終的な回答を提供してください。
+          #レビュー機能の設定
+          GITHUB_ACTION.AUTO_REVIEW: true
+          pr_reviewer.extra_instructions: "- 日本語でコメントしてください。 - This is a TypeScript project running on Akashic Engine, creating a game to be executed on the Niconico Live platform."
+          pr_reviewer.require_score_review: true #スコアを付ける
+          pr_reviewer.require_tests_review: false #テストについてはレビューしない
+          pr_reviewer.enable_review_labels_effort: false #レビューの重さラベルを付けない
+          pr_reviewer.enable_review_labels_security: false #セキュリティラベルを付けない
+          pr_reviewer.final_update_message: false #最終更新メッセージを追加する必要はない
+          pr_reviewer.inline_code_comments: true #インラインでのコメントOK
 
-              - *ウォークスルー*: 特定のファイルではなく、全体の変更に関する高レベルの要約を80語以内で。
-              - *変更点*: ファイルとその要約のテーブル。スペースを節約するために、同様の変更を持つファイルを1行にまとめることができます。
+          #概要機能の設定
+          GITHUB_ACTION.AUTO_DESCRIBE: true
+          pr_description.extra_instructions: "- 日本語でコメントしてください。 - This is a TypeScript project running on Akashic Engine, creating a game to be executed on the Niconico Live platform."
+          pr_description.final_update_message: false #最終更新メッセージを追加する必要はない
+          pr_description.publish_labels: false #ラベルを追加しない
 
-            GitHubのプルリクエストにコメントとして追加されるこの要約には、追加のコメントを避けてください。
+          #提案機能の設定
+          GITHUB_ACTION.AUTO_IMPROVE: false
+          pr_code_suggestions.extra_instructions: "- 日本語でコメントしてください。 - This is a TypeScript project running on Akashic Engine, creating a game to be executed on the Niconico Live platform."
+          pr_code_suggestions.rank_suggestions: true #提案をランク付けする


### PR DESCRIPTION
# 概要
AIレビューをCodeRabbitからPR-Agentに変更する
fix #2 

# やったこと
- .yamlをPR-Agent用のものに修正した

# やってないこと
- PR-Agentの仕様などについてWikiに文書を作成予定だが未対応

# 備考
- 動作することはプライベートリポジトリで確認済み
- レビューのしようもないと思うので一旦マージしてもらう感じで…